### PR TITLE
Modify Dockerfile to support daemon separation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,18 +16,18 @@ COPY main.go $DIR/
 COPY amo $DIR/amo
 RUN make TARGET=linux
 
-FROM alpine:edge
+FROM amolabs/tendermint-amo:latest
 
-RUN apk add --update ca-certificates
+# tendermint base image uses /tendermint as a home directory
+WORKDIR /tendermint
 
-WORKDIR /root
+#RUN apk add --update ca-certificates
 
 COPY --from=builder /go/src/github.com/amolabs/amoabci/amod /usr/bin/amod
-COPY run.sh /root
-COPY config/* /root/
+COPY run.sh config/* ./
 
 EXPOSE 26656 26657
 
-# TODO: use ENTRYPOINT
-#CMD ["amod"]
-CMD ["/bin/sh", "/root/run.sh"]
+# We need to override ENTRYPOINT from tendermint base image.
+ENTRYPOINT ["/bin/sh"]
+CMD ["/tendermint/run.sh"]

--- a/README.md
+++ b/README.md
@@ -55,15 +55,30 @@ tendermint node
 For test setup details, see [test-env.md](https://github.com/amolabs/docs/blob/master/test-env.md).
 
 ### Pre-requisites
+* [tendermint-amo](https://github.com/amolabs/tendermint-amo)
 * [docker](https://www.docker.com)
 * [docker-compose](https://www.docker.com)
 
-### Run
-To build docker image, run:
+### Build
+First, we need to build tendermint node image, and use it as a base image when
+building an amod image.
 ```bash
+cd $GOPATH/src/github.com/amolabs/tendermint-amo
+make build-linux
+make build-docker
+```
+This will put an image with the tag amolabs/tendermint-amo:latest in the local image pool.
+
+Next, build an amod image
+```bash
+cd $GOPATH/src/github.com/amolabs/amoabci
 make docker
 ```
+This will put an image with the tag amod:latest in the local image pool.
+
+### Run
 To run test containers using docker-compose, run:
 ```bash
 make run-cluster
 ```
+This will run one seed node and two non-seed validator nodes.

--- a/config/genesis.json
+++ b/config/genesis.json
@@ -1,0 +1,30 @@
+{
+  "genesis_time": "2019-02-21T08:32:00.52824293Z",
+  "chain_id": "amo-test-dev",
+  "consensus_params": {
+    "block_size": {
+      "max_bytes": "22020096",
+      "max_gas": "-1"
+    },
+    "evidence": {
+      "max_age": "100000"
+    },
+    "validator": {
+      "pub_key_types": [
+        "ed25519"
+      ]
+    }
+  },
+  "validators": [
+    {
+      "address": "E0D7123DD8D0D54AC52D84D96C02F648C2135ABC",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "Vikc0Un70QMr5e8JczAKi9NPuncR3tf6529zGyupXO0="
+      },
+      "power": "10",
+      "name": ""
+    }
+  ],
+  "app_hash": ""
+}

--- a/run.sh
+++ b/run.sh
@@ -6,12 +6,17 @@ echo "set seeds =" $SEEDS
 cp config.toml.in config.toml
 sed -e s/@moniker@/$MONIKER/ -i.tmp config.toml
 sed -e s/@seeds@/$SEEDS/ -i.tmp config.toml
-mkdir -p blockchain/config
-mkdir -p blockchain/data
-mv -f config.toml blockchain/config/
+mkdir config
+mkdir data
+mv -f config.toml config/
 if [ "$MONIKER" == "seed" ]; then
-	cp node_key.json blockchain/config/
-	cp priv_validator_key.json blockchain/config/
-	cp priv_validator_state.json blockchain/data/
+	mv node_key.json config/
+	mv priv_validator_key.json config/
+	mv priv_validator_state.json data/
 fi
-amod
+mv genesis.json config/
+amod &
+if [ "$MONIKER" == "seed" ]; then
+	/usr/bin/tendermint init
+fi
+/usr/bin/tendermint node


### PR DESCRIPTION
- Second stage of the 'docker build' will use tendermint docker image as a base
  image.
- Override ENTRYPOINT in the amod image, for we need to run amod before
  tendermint node.
- Add instructions for building tendermint docker image.
- Add pre-defined genesis.json file to sync chain_id across tendermint nodes.

closes #13 