### PR TITLE
Import console app code from amoconsole repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,5 +29,5 @@ jobs:
       # specify any bash command here prefixed with `run: `
       #- run: go get -v -t -d ./...
       #- run: go test -v ./...
-      - run: make vendor-deps
+      - run: make get_vendor_deps
       - run: make

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR $DIR
 COPY Makefile Gopkg.toml Gopkg.lock $DIR/
 
 RUN apk add --no-cache $PACKAGES \
-    && make tools \
-    && make vendor-deps
+    && make get_tools \
+    && make get_vendor_deps
 
 COPY main.go $DIR/
 COPY amo $DIR/amo

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,7 +3,7 @@
 
 [[projects]]
   branch = "release/v0.29.2a"
-  digest = "1:d70b91210541bc43a42a6543e18356a2eee724dcb881c3fbac879b56dc77c812"
+  digest = "1:065bb23f4d4fda646421f77e74be185a908863a2a65856c0df932556b0de2c11"
   name = "github.com/amolabs/tendermint-amo"
   packages = [
     "abci/client",
@@ -42,9 +42,11 @@
     "p2p/pex",
     "privval",
     "proxy",
+    "rpc/client",
     "rpc/core",
     "rpc/core/types",
     "rpc/grpc",
+    "rpc/lib/client",
     "rpc/lib/server",
     "rpc/lib/types",
     "state",
@@ -56,7 +58,7 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "cd009530f8520a81d21b9808ae65c760517da9c6"
+  revision = "bec9bc5d8d3cd3a04e096e3d00f6dbbbd4e8e635"
 
 [[projects]]
   branch = "master"
@@ -159,12 +161,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:4a0c6bb4805508a6287675fac876be2ac1182539ca8a32468d8128882e9d5009"
+  digest = "1:e4f5819333ac698d294fe04dbf640f84719658d5c7ce195b10060cc37292ce79"
   name = "github.com/golang/snappy"
   packages = ["."]
   pruneopts = "UT"
-  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
+  revision = "2a8bb927dd31d8daada140a5d09578521ce5c36a"
+  version = "v0.0.1"
 
 [[projects]]
   digest = "1:7b5c6e2eeaa9ae5907c391a91c132abfd5c9e8a784a341b5625e750c67e6825d"
@@ -192,6 +194,14 @@
   pruneopts = "UT"
   revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
+  name = "github.com/inconshreveable/mousetrap"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+  version = "v1.0"
 
 [[projects]]
   branch = "master"
@@ -275,10 +285,10 @@
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = "UT"
-  revision = "56726106282f1985ea77d5305743db7231b0c0a8"
+  revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
 
 [[projects]]
-  digest = "1:ce62b400185bf6b16ef6088011b719e449f5c15c4adb6821589679f752c2788e"
+  digest = "1:35cf6bdf68db765988baa9c4f10cc5d7dda1126a54bd62e252dbcd0b1fc8da90"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -286,21 +296,29 @@
     "model",
   ]
   pruneopts = "UT"
-  revision = "2998b132700a7d019ff618c06a234b47c1f3f681"
-  version = "v0.1.0"
+  revision = "cfeb6f9992ffa54aaa4f2170ade4067ee478b250"
+  version = "v0.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:f532f2cdb9e9e4a8fad5a7e944482f4dd12650228e4a7a6c8492a0d069ce0690"
+  digest = "1:ca30ee2c96d195cef49b546d10825d3e13b50c63da4df23c80e77c51e07bad0d"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
+    "iostats",
     "nfs",
     "xfs",
   ]
   pruneopts = "UT"
-  revision = "bf6a532e95b1f7a62adf0ab5050a5bb2237ad2f4"
+  revision = "e4d4a2206da023361ed100d85c5f2cf9c8364e9f"
+
+[[projects]]
+  digest = "1:c4556a44e350b50a490544d9b06e9fba9c286c21d6c0e47f54f3a9214597298c"
+  name = "github.com/rcrowley/go-metrics"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e2704e165165ec55d062f5919b4b29494e9fa790"
 
 [[projects]]
   digest = "1:b0c25f00bad20d783d259af2af8666969e2fc343fa0dc9efe52936bbd67fb758"
@@ -328,6 +346,14 @@
   pruneopts = "UT"
   revision = "8c9545af88b134710ab1cd196795e7f2388358d7"
   version = "v1.3.0"
+
+[[projects]]
+  digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
+  name = "github.com/spf13/cobra"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
 
 [[projects]]
   digest = "1:68ea4e23713989dc20b1bded5d9da2c5f9be14ff9885beef481848edd18c26cb"
@@ -365,8 +391,7 @@
   version = "v1.3.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:685fdfea42d825ebd39ee0994354b46c374cf2c2b2d97a41a8dee1807c6a9b62"
+  digest = "1:5b180f17d5bc50b765f4dcf0d126c72979531cbbd7f7929bf3edd87fb801ea2d"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -383,7 +408,8 @@
     "leveldb/util",
   ]
   pruneopts = "UT"
-  revision = "b001fa50d6b27f3f0bb175a87d0cb55426d0a0ae"
+  revision = "9d007e481048296f09f59bd19bb7ae584563cd95"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:ad9c4c1a4e7875330b1f62906f2830f043a23edb5db997e3a5ac5d3e6eadf80a"
@@ -431,14 +457,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f57463f4558fe0125807362c3087faab4b6cc76d1525ac8bb32cee0d205c745c"
+  digest = "1:ad5e62a015226e008f9ca24cdf00d65c74f004f1b247cfa033ca9e3afcf41b29"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
     "unix",
   ]
   pruneopts = "UT"
-  revision = "054c452bb702e465e95ce8e7a3d9a6cf0cd1188d"
+  revision = "cd391775e71e684db52b63df9affd58269495083"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -469,7 +495,7 @@
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "UT"
-  revision = "8819c946db4494a2259bf100a377f51aa585d893"
+  revision = "082222b4a5c572e33e82ee9162d1352c7cf38682"
 
 [[projects]]
   digest = "1:9ab5a33d8cb5c120602a34d2e985ce17956a4e8c2edce7e6961568f95e40c09a"
@@ -538,6 +564,7 @@
     "github.com/amolabs/tendermint-amo/p2p/conn",
     "github.com/amolabs/tendermint-amo/privval",
     "github.com/amolabs/tendermint-amo/proxy",
+    "github.com/amolabs/tendermint-amo/rpc/client",
     "github.com/amolabs/tendermint-amo/rpc/core",
     "github.com/amolabs/tendermint-amo/rpc/core/types",
     "github.com/amolabs/tendermint-amo/rpc/lib/server",
@@ -545,6 +572,7 @@
     "github.com/amolabs/tendermint-amo/types/time",
     "github.com/amolabs/tendermint-amo/version",
     "github.com/pkg/errors",
+    "github.com/spf13/cobra",
     "github.com/spf13/viper",
     "github.com/stretchr/testify/require",
     "github.com/tendermint/go-amino",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,10 +24,13 @@
 #   go-tests = true
 #   unused-packages = true
 
-
 [[constraint]]
   name = "github.com/amolabs/tendermint-amo"
   branch = "release/v0.29.2a"
+
+[[constraint]]
+  name = "github.com/spf13/cobra"
+  version = "~0.0.1"
 
 [prune]
   go-tests = true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build docker run-cluster test
 
-all: build
+all: install
 
 GO := $(shell command -v go 2> /dev/null)
 FS := /
@@ -58,13 +58,22 @@ vendor-deps:
 	@dep ensure -v -vendor-only
 
 build:
-	@echo "--> Building amo daemon"
-	$(BUILDENV) go build -a -o amod .
+	@echo "--> Building amo daemon (amod)"
+	go build ./cmd/amod
+	@echo "--> Building amo console (amocli)"
+	go build ./cmd/amocli
+
+install:
+	@echo "--> Installing amo daemon (amod)"
+	go install ./cmd/amod
+	@echo "--> Installing amo console (amocli)"
+	go install ./cmd/amocli
 
 test:
 	go test ./...
 
 docker:
+	go build -o amod ./cmd/amod
 	docker build -t amod .
 
 run-cluster: docker

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ tags: $(GOSRCS)
 	gotags -R -f tags .
 
 #tools: $(GOPATH)/bin/dep $(GOPATH)/bin/gometalinter $(GOPATH)/bin/statik $(GOPATH)/bin/goimports
-tools: $(GOPATH)/bin/dep
+get_tools: $(GOPATH)/bin/dep
 
 $(GOPATH)/bin/dep:
 	$(call go_get,golang,dep,22125cfaa6ddc71e145b1535d4b7ee9744fefff2)
@@ -52,10 +52,15 @@ $(GOPATH)/bin/statik:
 $(GOPATH)/bin/goimports:
 	go get golang.org/x/tools/cmd/goimports
 
-vendor-deps:
+get_vendor_deps:
 	@echo "--> Generating vendor directory via dep ensure"
 	@rm -rf .vendor-new
 	@dep ensure -v -vendor-only
+
+update_vendor_deps:
+	@echo "--> Running dep ensure"
+	@rm -rf .vendor-new
+	@dep ensure -v -update
 
 build:
 	@echo "--> Building amo daemon (amod)"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Tendermint ABCI App for AMO blockchain
 
+<!--
 ***NOTE: Tendermint node and the app are built into one single binary in current implementation. This may change in the future.***
+-->
 
 ## Installation
 ### Pre-requisites
@@ -9,19 +11,22 @@
 * [tendermint](https://github.com/tendermint/tendermint)
 
 ### Build from source
-* <s>run commands to build Tendermint node:</s>
+* <s>run commands to build Tendermint-amo node:</s>
 ```bash
-git clone https://github.com/tendermint/tendermint
+git clone https://github.com/amolabs/tendermint-amo
+cd tendermint-amo
 make get_tools
 make get_vendor_deps
 make install
 ```
 
-* run commands to build AMO ABCI app:
+* run commands to install AMO ABCI app (amod, amocli) :
 ```bash
 git clone https://github.com/amolabs/amoabci
 cd amoabci
-make
+make get_tools
+make get_vendor_deps
+make install
 ```
 In order to build for another platform (cross-compile) use `TARGET` variable. ex)
 ```bash
@@ -36,7 +41,7 @@ make TARGET=linux
 ### Run ABCI app
 * run commands:
 ```bash
-amod
+amod run
 ```
 
 ### Prepare keys
@@ -45,7 +50,7 @@ amod
 tendermint init
 ```
 
-### <s>Run Tendermint node</s>
+### Run Tendermint node
 * run commands:
 ```bash
 tendermint node

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 * [tendermint](https://github.com/tendermint/tendermint)
 
 ### Build from source
-* <s>run commands to build Tendermint-amo node:</s>
+* run commands to build Tendermint-amo node:
 ```bash
 git clone https://github.com/amolabs/tendermint-amo
 cd tendermint-amo
@@ -20,7 +20,7 @@ make get_vendor_deps
 make install
 ```
 
-* run commands to install AMO ABCI app (amod, amocli) :
+* run commands to install AMO ABCI app (amod, amocli):
 ```bash
 git clone https://github.com/amolabs/amoabci
 cd amoabci

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ make install
 ```
 In order to build for another platform (cross-compile) use `TARGET` variable. ex)
 ```bash
-make TARGET=linux
+make TARGET=linux install
 ```
 
 ### Gather network information

--- a/cmd/amocli/cmd/key.go
+++ b/cmd/amocli/cmd/key.go
@@ -8,15 +8,15 @@ import (
 
 /* Commands (expected hierarchy)
  *
- * amoconsole |- key |- list
- *		  			 |- generate <nickname>
- *				 	 |- remove <nickname>
+ * amocli |- key |- list
+ *				 |- generate <nickname>
+ *			 	 |- remove <nickname>
  */
 
 var keyCmd = &cobra.Command{
 	Use:     "key",
 	Aliases: []string{"k"},
-	Short:   "Manages the key(wallet)-related features",
+	Short:   "Manage the key(wallet)-related features",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := cmd.Help(); err != nil {
 			return err
@@ -37,7 +37,7 @@ func init() {
 
 var keyListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "Shows all of keys stored on the local storage",
+	Short: "Show all of keys stored on the local storage",
 	Args:  cobra.NoArgs,
 	RunE:  keyListFunc,
 }
@@ -48,7 +48,7 @@ func keyListFunc(cmd *cobra.Command, args []string) error {
 
 var keyGenCmd = &cobra.Command{
 	Use:   "generate [nickname]",
-	Short: "Generates a key with a specified nickname",
+	Short: "Generate a key with a specified nickname",
 	Args:  cobra.MinimumNArgs(1),
 	RunE:  keyGenFunc,
 }
@@ -65,7 +65,7 @@ func keyGenFunc(cmd *cobra.Command, args []string) error {
 
 var keyRemoveCmd = &cobra.Command{
 	Use:   "remove [nickname]",
-	Short: "Removes the specified key",
+	Short: "Remove the specified key",
 	Args:  cobra.MinimumNArgs(1),
 	RunE:  keyRemoveFunc,
 }

--- a/cmd/amocli/cmd/key.go
+++ b/cmd/amocli/cmd/key.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+/* Commands (expected hierarchy)
+ *
+ * amoconsole |- key |- list
+ *		  			 |- generate <nickname>
+ *				 	 |- remove <nickname>
+ */
+
+var keyCmd = &cobra.Command{
+	Use:     "key",
+	Aliases: []string{"k"},
+	Short:   "Manages the key(wallet)-related features",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := cmd.Help(); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	listCmd := keyListCmd
+	genCmd := keyGenCmd
+	removeCmd := keyRemoveCmd
+
+	cmd := keyCmd
+	cmd.AddCommand(listCmd, genCmd, removeCmd)
+}
+
+var keyListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Shows all of keys stored on the local storage",
+	Args:  cobra.NoArgs,
+	RunE:  keyListFunc,
+}
+
+func keyListFunc(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+var keyGenCmd = &cobra.Command{
+	Use:   "generate [nickname]",
+	Short: "Generates a key with a specified nickname",
+	Args:  cobra.MinimumNArgs(1),
+	RunE:  keyGenFunc,
+}
+
+func keyGenFunc(cmd *cobra.Command, args []string) error {
+	var nickname string
+
+	nickname = args[0]
+
+	fmt.Println(nickname)
+
+	return nil
+}
+
+var keyRemoveCmd = &cobra.Command{
+	Use:   "remove [nickname]",
+	Short: "Removes the specified key",
+	Args:  cobra.MinimumNArgs(1),
+	RunE:  keyRemoveFunc,
+}
+
+func keyRemoveFunc(cmd *cobra.Command, args []string) error {
+	var nickname string
+
+	nickname = args[0]
+
+	fmt.Println(nickname)
+
+	return nil
+}

--- a/cmd/amocli/cmd/query.go
+++ b/cmd/amocli/cmd/query.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	atypes "github.com/amolabs/amoabci/amo/types"
+	"github.com/amolabs/amoabci/cmd/amocli/tx"
+)
+
+/* Commands (expected hierarchy)
+ *
+ * amoconsole |- query |- address
+ */
+
+var queryCmd = &cobra.Command{
+	Use:     "query",
+	Aliases: []string{"q"},
+	Short:   "Performs a query ...",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := cmd.Help(); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var queryAddressCmd = &cobra.Command{
+	Use:   "address [address]",
+	Short: "Shows address's general information",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		target := atypes.NewAddress([]byte(args[0]))
+		targetInfo, err := tx.QueryAddressInfo(*target)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(targetInfo))
+
+		return nil
+	},
+}
+
+func init() {
+	// init here if needed
+	addressCmd := queryAddressCmd
+	cmd := queryCmd
+	cmd.AddCommand(addressCmd)
+}

--- a/cmd/amocli/cmd/query.go
+++ b/cmd/amocli/cmd/query.go
@@ -11,13 +11,13 @@ import (
 
 /* Commands (expected hierarchy)
  *
- * amoconsole |- query |- address
+ * amocli |- query |- address
  */
 
 var queryCmd = &cobra.Command{
 	Use:     "query",
 	Aliases: []string{"q"},
-	Short:   "Performs a query ...",
+	Short:   "Performs the query specified by users",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := cmd.Help(); err != nil {
 			return err
@@ -29,7 +29,7 @@ var queryCmd = &cobra.Command{
 
 var queryAddressCmd = &cobra.Command{
 	Use:   "address [address]",
-	Short: "Shows address's general information",
+	Short: "Show general information of specified address",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		target := atypes.NewAddress([]byte(args[0]))

--- a/cmd/amocli/cmd/root.go
+++ b/cmd/amocli/cmd/root.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:               "amoconsole",
+	Short:             "Console app for a user to interact with 'amo' daemon",
+	PersistentPreRunE: loadConfig,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := cmd.Help(); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+// Execute function is the main gate to this app
+func Execute() {
+	cobra.EnableCommandSorting = false
+
+	rootCmd.AddCommand(
+		versionCmd,
+		statusCmd,
+		keyCmd,
+		txCmd,
+		queryCmd)
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func loadConfig(cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/amocli/cmd/root.go
+++ b/cmd/amocli/cmd/root.go
@@ -8,8 +8,8 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:               "amoconsole",
-	Short:             "Console app for a user to interact with 'amo' daemon",
+	Use:               "amocli",
+	Short:             "Console app for a user to interact with AMO daemon",
 	PersistentPreRunE: loadConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := cmd.Help(); err != nil {

--- a/cmd/amocli/cmd/status.go
+++ b/cmd/amocli/cmd/status.go
@@ -10,8 +10,8 @@ import (
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Shows status of AMO node",
-	Long:  "Shows including node info, pubkey, latest block hash, app hash, block height and time",
+	Short: "Show status of AMO node",
+	Long:  "Show status of AMO node including node info, pubkey, latest block hash, app hash, block height and time",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		result, err := util.RPCStatus()
 		if err != nil {

--- a/cmd/amocli/cmd/status.go
+++ b/cmd/amocli/cmd/status.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/amolabs/amoabci/cmd/amocli/util"
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Shows status of AMO node",
+	Long:  "Shows including node info, pubkey, latest block hash, app hash, block height and time",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		result, err := util.RPCStatus()
+		if err != nil {
+			return err
+		}
+
+		resultJSON, err := json.Marshal(result)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(resultJSON))
+
+		return nil
+	},
+}
+
+func init() {
+	// init here if needed
+}

--- a/cmd/amocli/cmd/tx.go
+++ b/cmd/amocli/cmd/tx.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	atypes "github.com/amolabs/amoabci/amo/types"
+	"github.com/amolabs/amoabci/cmd/amocli/tx"
+)
+
+/* Commands (expected hierarchy)
+ *
+ * amoconsole |- tx |- transfer --from <address> --to <address> --amount <number>
+ *		    		|- purchase --from <address> --file <hash>
+ */
+
+var txCmd = &cobra.Command{
+	Use:     "tx",
+	Aliases: []string{"t"},
+	Short:   "Performs a transaction",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := cmd.Help(); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var txTransferCmd = &cobra.Command{
+	Use:   "transfer",
+	Short: "Transfers the specified amount of money from <address> to <address>",
+	Args:  cobra.NoArgs,
+	RunE:  txTransferFunc,
+}
+
+var txPurchaseCmd = &cobra.Command{
+	Use:   "purchase",
+	Short: "Purchases the file specified with file's <hash>",
+	Args:  cobra.NoArgs,
+	RunE:  txPurchaseFunc,
+}
+
+func init() {
+	transferCmd := txTransferCmd
+	transferCmd.Flags().SortFlags = false
+
+	transferCmd.Flags().String("from", "", "ex) a8cxVrk1ju91UaJf7U1Hscgn3sRqzfmjgg")
+	transferCmd.Flags().String("to", "", "ex) aH2JdDUP5NoFmeEQEqDREZnkmCh8V7co7y")
+	transferCmd.Flags().Uint64("amount", 0, "specify 'amount'")
+	transferCmd.MarkFlagRequired("from")
+	transferCmd.MarkFlagRequired("to")
+	transferCmd.MarkFlagRequired("amount")
+
+	purchaseCmd := txPurchaseCmd
+	purchaseCmd.Flags().SortFlags = false
+
+	purchaseCmd.Flags().String("from", "", "ex) a8cxVrk1ju91UaJf7U1Hscgn3sRqzfmjgg")
+	purchaseCmd.Flags().String("file_hash", "", "ex) 0xb94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
+	purchaseCmd.MarkFlagRequired("from")
+	purchaseCmd.MarkFlagRequired("file_hash")
+
+	cmd := txCmd
+	cmd.AddCommand(transferCmd, purchaseCmd)
+}
+
+func txTransferFunc(cmd *cobra.Command, args []string) error {
+	var from, to string
+	var amount uint64
+	var err error
+
+	flags := cmd.Flags()
+
+	if from, err = flags.GetString("from"); err != nil {
+		return err
+	}
+	if to, err = flags.GetString("to"); err != nil {
+		return err
+	}
+	if amount, err = flags.GetUint64("amount"); err != nil {
+		return err
+	}
+
+	fromAddr := atypes.NewAddress([]byte(from))
+	toAddr := atypes.NewAddress([]byte(to))
+
+	result, err := tx.Transfer(*fromAddr, *toAddr, &amount)
+	if err != nil {
+		return err
+	}
+
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(resultJSON))
+
+	return nil
+}
+
+func txPurchaseFunc(cmd *cobra.Command, args []string) error {
+	var from, fileHashString string
+	var err error
+
+	flags := cmd.Flags()
+
+	if from, err = flags.GetString("from"); err != nil {
+		return err
+	}
+	if fileHashString, err = flags.GetString("file_hash"); err != nil {
+		return err
+	}
+
+	fileHashString = strings.TrimLeft(fileHashString, "0x")
+
+	fromAddr := atypes.NewAddress([]byte(from))
+	fileHash := atypes.NewHashFromHexString(fileHashString)
+
+	result, err := tx.Purchase(*fromAddr, *fileHash)
+	if err != nil {
+		return err
+	}
+
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(resultJSON))
+
+	return nil
+}

--- a/cmd/amocli/cmd/tx.go
+++ b/cmd/amocli/cmd/tx.go
@@ -13,14 +13,14 @@ import (
 
 /* Commands (expected hierarchy)
  *
- * amoconsole |- tx |- transfer --from <address> --to <address> --amount <number>
- *		    		|- purchase --from <address> --file <hash>
+ * amocli |- tx |- transfer --from <address> --to <address> --amount <number>
+ *		    	|- purchase --from <address> --file <hash>
  */
 
 var txCmd = &cobra.Command{
 	Use:     "tx",
 	Aliases: []string{"t"},
-	Short:   "Performs a transaction",
+	Short:   "Perform a transaction",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := cmd.Help(); err != nil {
 			return err
@@ -32,14 +32,14 @@ var txCmd = &cobra.Command{
 
 var txTransferCmd = &cobra.Command{
 	Use:   "transfer",
-	Short: "Transfers the specified amount of money from <address> to <address>",
+	Short: "Transfer the specified amount of money from <address> to <address>",
 	Args:  cobra.NoArgs,
 	RunE:  txTransferFunc,
 }
 
 var txPurchaseCmd = &cobra.Command{
 	Use:   "purchase",
-	Short: "Purchases the file specified with file's <hash>",
+	Short: "Purchase the file specified with file's <hash>",
 	Args:  cobra.NoArgs,
 	RunE:  txPurchaseFunc,
 }

--- a/cmd/amocli/cmd/version.go
+++ b/cmd/amocli/cmd/version.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// VERSION represents the general version of this app
+const VERSION = "0.1"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Shows version info",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(VERSION)
+	},
+}
+
+func init() {
+	// init here if needed
+}

--- a/cmd/amocli/cmd/version.go
+++ b/cmd/amocli/cmd/version.go
@@ -11,7 +11,7 @@ const VERSION = "0.1"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Shows version info",
+	Short: "Show version info",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(VERSION)
 	},

--- a/cmd/amocli/main.go
+++ b/cmd/amocli/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/amolabs/amoabci/cmd/amocli/cmd"
+)
+
+/* Commands (expected hierarchy)
+ *
+ * amoconsole |- version
+ *		  	  |- status
+ * 		  	  |- key |- list
+ *		  	   		 |- generate <nickname>
+ *					 |- remove <nickname>
+ *
+ *		  	  |- tx |- transfer --from <address> --to <address> --amount <number>
+ *		  			|- purchase --from <address> --file <hash>
+ *
+ *		  	  |- query |- address <address>
+ */
+
+func main() {
+	cmd.Execute()
+}

--- a/cmd/amocli/main.go
+++ b/cmd/amocli/main.go
@@ -6,16 +6,16 @@ import (
 
 /* Commands (expected hierarchy)
  *
- * amoconsole |- version
- *		  	  |- status
- * 		  	  |- key |- list
- *		  	   		 |- generate <nickname>
- *					 |- remove <nickname>
+ * amocli |- version
+ *		  |- status
+ * 		  |- key |- list
+ *		  		 |- generate <nickname>
+ *				 |- remove <nickname>
  *
- *		  	  |- tx |- transfer --from <address> --to <address> --amount <number>
- *		  			|- purchase --from <address> --file <hash>
+ *		  |- tx |- transfer --from <address> --to <address> --amount <number>
+ *		  		|- purchase --from <address> --file <hash>
  *
- *		  	  |- query |- address <address>
+ *		  |- query |- address <address>
  */
 
 func main() {

--- a/cmd/amocli/tx/broadcast.go
+++ b/cmd/amocli/tx/broadcast.go
@@ -1,0 +1,25 @@
+package tx
+
+import (
+	ctypes "github.com/amolabs/tendermint-amo/rpc/core/types"
+
+	atypes "github.com/amolabs/amoabci/amo/types"
+	"github.com/amolabs/amoabci/cmd/amocli/util"
+)
+
+// Transfer handles transfer transaction
+func Transfer(from, to atypes.Address, amount *uint64) (*ctypes.ResultBroadcastTxCommit, error) {
+	return util.RPCBroadcastTxCommit(util.MakeMessage(atypes.TxTransfer, atypes.Transfer{
+		From:   from,
+		To:     to,
+		Amount: *amount,
+	}))
+}
+
+// Purchase handles purchase transaction
+func Purchase(from atypes.Address, fileHash atypes.Hash) (*ctypes.ResultBroadcastTxCommit, error) {
+	return util.RPCBroadcastTxCommit(util.MakeMessage(atypes.TxPurchase, atypes.Purchase{
+		From:     from,
+		FileHash: fileHash,
+	}))
+}

--- a/cmd/amocli/tx/query.go
+++ b/cmd/amocli/tx/query.go
@@ -1,0 +1,16 @@
+package tx
+
+import (
+	atypes "github.com/amolabs/amoabci/amo/types"
+	"github.com/amolabs/amoabci/cmd/amocli/util"
+)
+
+// QueryAddressInfo is ..
+func QueryAddressInfo(target atypes.Address) ([]byte, error) {
+	result, err := util.RPCABCIQuery("", target[:])
+	if err != nil {
+		return nil, err
+	}
+
+	return result.Response.Value, nil
+}

--- a/cmd/amocli/util/rpc.go
+++ b/cmd/amocli/util/rpc.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"encoding/json"
+
+	atypes "github.com/amolabs/amoabci/amo/types"
+
+	cmn "github.com/amolabs/tendermint-amo/libs/common"
+	"github.com/amolabs/tendermint-amo/rpc/client"
+	ctypes "github.com/amolabs/tendermint-amo/rpc/core/types"
+	"github.com/amolabs/tendermint-amo/types"
+	tmtime "github.com/amolabs/tendermint-amo/types/time"
+)
+
+var (
+	rpcRemote     = "tcp://0.0.0.0:26657"
+	rpcWsEndpoint = "/websocket"
+)
+
+// MakeMessage handles making tx message
+func MakeMessage(t string, payload interface{}) types.Tx {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	msg := atypes.Message{
+		Command:   t,
+		Timestamp: tmtime.Now().Unix(),
+		Payload:   raw,
+	}
+	tx, err := json.Marshal(msg)
+	if err != nil {
+		panic(err)
+	}
+	return tx
+}
+
+// RPCBroadcastTxCommit handles sending transactions
+func RPCBroadcastTxCommit(tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
+	cli := client.NewHTTP(rpcRemote, rpcWsEndpoint)
+	return cli.BroadcastTxCommit(tx)
+}
+
+// RPCABCIQuery handles querying
+func RPCABCIQuery(path string, data cmn.HexBytes) (*ctypes.ResultABCIQuery, error) {
+	cli := client.NewHTTP(rpcRemote, rpcWsEndpoint)
+	return cli.ABCIQuery(path, data)
+}
+
+// RPCStatus handle querying the status
+func RPCStatus() (*ctypes.ResultStatus, error) {
+	cli := client.NewHTTP(rpcRemote, rpcWsEndpoint)
+	return cli.Status()
+}

--- a/cmd/amod/cmd/root.go
+++ b/cmd/amod/cmd/root.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:               "amod",
+	Short:             "'amo' daemon",
+	PersistentPreRunE: loadConfig,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := cmd.Help(); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+// Execute function is the main gate to this app
+func Execute() {
+	cobra.EnableCommandSorting = false
+
+	rootCmd.AddCommand(runCmd)
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func loadConfig(cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/amod/cmd/root.go
+++ b/cmd/amod/cmd/root.go
@@ -9,7 +9,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:               "amod",
-	Short:             "'amo' daemon",
+	Short:             "AMO daemon management",
 	PersistentPreRunE: loadConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := cmd.Help(); err != nil {

--- a/cmd/amod/cmd/run.go
+++ b/cmd/amod/cmd/run.go
@@ -19,7 +19,7 @@ import (
 
 var runCmd = &cobra.Command{
 	Use:	"run",
-	Short:	"Executes the 'amo' daemon",
+	Short:	"Execute the daemon",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := initApp()
 		if err != nil {

--- a/cmd/amod/cmd/run.go
+++ b/cmd/amod/cmd/run.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"os"
@@ -8,13 +8,25 @@ import (
 	"github.com/amolabs/tendermint-amo/abci/types"
 	cmn "github.com/amolabs/tendermint-amo/libs/common"
 	"github.com/amolabs/tendermint-amo/libs/log"
+
+	"github.com/spf13/cobra"
 )
 
-func main() {
-	err := initApp()
-	if err != nil {
-		panic(err)
-	}
+/* Commands (expected hierarchy)
+ *
+ * amod |- run
+ */
+
+var runCmd = &cobra.Command{
+	Use:	"run",
+	Short:	"Executes the 'amo' daemon",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := initApp()
+		if err != nil {
+			return err
+		}
+		return nil
+	},
 }
 
 func initApp() error {
@@ -41,4 +53,8 @@ func initApp() error {
 		}
 	})
 	return nil
+}
+
+func init() {
+	// init here if needed
 }

--- a/cmd/amod/main.go
+++ b/cmd/amod/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/amolabs/amoabci/cmd/amod/cmd"
+)
+
+/* Commands (expected hierarchy)
+ *
+ * amod |- run 
+ */
+
+func main() {
+	cmd.Execute()
+}

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ if [ "$MONIKER" == "seed" ]; then
 	mv priv_validator_state.json data/
 fi
 mv genesis.json config/
-amod &
+amod run &
 if [ "$MONIKER" == "seed" ]; then
 	/usr/bin/tendermint init
 fi


### PR DESCRIPTION
This integration comes with the changed method to install the AMO abci app.
From now on, the app contains two programs.

- 'amod' serving as a daemon managing the abci app.
- 'amocli' which was placed in the 'amoconsole' repository.

To see how it works, please check the commits and README.md 

:)

closes #4 
