### PR TITLE
Feature/41 add encrypted field to key list function

### DIFF
--- a/cmd/amocli/cmd/key.go
+++ b/cmd/amocli/cmd/key.go
@@ -55,7 +55,9 @@ var keyListCmd = &cobra.Command{
 }
 
 func keyListFunc(cmd *cobra.Command, args []string) error {
-	err := keys.List()
+	keyFile := util.DefaultKeyFilePath()
+
+	err := keys.List(keyFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/amocli/keys/list.go
+++ b/cmd/amocli/keys/list.go
@@ -3,14 +3,10 @@ package keys
 import (
 	"fmt"
 	"sort"
-
-	"github.com/amolabs/amoabci/cmd/amocli/util"
 )
 
-func List() error {
-	keyFile := util.DefaultKeyFilePath()
-
-	keyList, err := LoadKeyList(keyFile)
+func List(path string) error {
+	keyList, err := LoadKeyList(path)
 	if err != nil {
 		return err
 	}

--- a/cmd/amocli/keys/list.go
+++ b/cmd/amocli/keys/list.go
@@ -18,16 +18,16 @@ func List(path string) error {
 
 	sort.Strings(sortKey)
 
-	fmt.Printf("%-3s %-10s %-20s %-40s\n",
-		"seq", "nickname", "type", "address")
+	fmt.Printf("%-3s %-10s %-20s %-10s %-40s\n",
+		"seq", "nickname", "type", "encrypted", "address")
 
 	i := 0
 	for _, nickname := range sortKey {
 		i++
 		key := keyList[nickname]
 
-		fmt.Printf("%-3d %-10s %-20s %-40s\n",
-			i, nickname, key.Type, key.Address)
+		fmt.Printf("%-3d %-10s %-20s %-10t %-40s\n",
+			i, nickname, key.Type, key.Encrypted, key.Address)
 	}
 
 	return nil


### PR DESCRIPTION
Add a new field, for usability, which shows whether a key(private) is encrypted or not on the list.

```
$ amocli key list
seq nickname   type                 encrypted  address                                 
1   alice      amo/PrivKeyP256      true       57C3B858C6C9109E98DDAFE644A1127412B7DC92
2   bob        amo/PrivKeyP256      false      9FDBF73881EA62E220A5E30935044F953B3F3339
```

closes https://github.com/amolabs/amoabci/issues/41