### PR TITLE
Fix amocli balance query command

### DIFF
--- a/client/rpc/query.go
+++ b/client/rpc/query.go
@@ -1,15 +1,22 @@
 package rpc
 
 import (
+	"encoding/json"
+
 	"github.com/amolabs/tendermint-amo/crypto"
+	tm "github.com/amolabs/tendermint-amo/libs/common"
+
+	"github.com/amolabs/amoabci/amo/types"
 )
 
-// QueryAddressInfo is ..
-func QueryAddressInfo(target crypto.Address) ([]byte, error) {
-	result, err := RPCABCIQuery("", target[:])
+func QueryBalance(address crypto.Address) (types.Currency, error) {
+	bytes, err := json.Marshal(address)
+	result, err := RPCABCIQuery("/balance", tm.HexBytes(bytes))
 	if err != nil {
-		return nil, err
+		return types.Currency(0), err
 	}
 
-	return result.Response.Value, nil
+	var balance types.Currency
+	json.Unmarshal(result.Response.Value, &balance)
+	return balance, nil
 }

--- a/cmd/amocli/cmd/query.go
+++ b/cmd/amocli/cmd/query.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"encoding/hex"
 	"fmt"
 
+	"github.com/amolabs/tendermint-amo/crypto"
 	"github.com/spf13/cobra"
 
 	"github.com/amolabs/amoabci/client/rpc"
@@ -10,7 +12,7 @@ import (
 
 /* Commands (expected hierarchy)
  *
- * amocli |- query |- address
+ * amocli |- query |- balance
  */
 
 var queryCmd = &cobra.Command{
@@ -26,18 +28,21 @@ var queryCmd = &cobra.Command{
 	},
 }
 
-var queryAddressCmd = &cobra.Command{
-	Use:   "address [address]",
-	Short: "Show general information of specified address",
+var queryBalanceCmd = &cobra.Command{
+	Use:   "balance [address]",
+	Short: "Show balance of an address",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		target := []byte(args[0])
-		targetInfo, err := rpc.QueryAddressInfo(target)
+		address, err := hex.DecodeString(args[0])
+		if err != nil {
+			return err
+		}
+		balance, err := rpc.QueryBalance(crypto.Address(address))
 		if err != nil {
 			return err
 		}
 
-		fmt.Println(string(targetInfo))
+		fmt.Println(balance)
 
 		return nil
 	},
@@ -45,7 +50,7 @@ var queryAddressCmd = &cobra.Command{
 
 func init() {
 	// init here if needed
-	addressCmd := queryAddressCmd
+	addressCmd := queryBalanceCmd
 	cmd := queryCmd
 	cmd.AddCommand(addressCmd)
 }


### PR DESCRIPTION
closes #44 

- change the name of the command from address to balance
- conformance to rpc.md document
