### PR TITLE
Add query for parcel-related data

### DIFF
--- a/amo/amo_test.go
+++ b/amo/amo_test.go
@@ -7,6 +7,8 @@ import (
 
 	abci "github.com/amolabs/tendermint-amo/abci/types"
 	"github.com/amolabs/tendermint-amo/crypto"
+	"github.com/amolabs/tendermint-amo/crypto/p256"
+	cmn "github.com/amolabs/tendermint-amo/libs/common"
 	tdb "github.com/amolabs/tendermint-amo/libs/db"
 	"github.com/stretchr/testify/assert"
 
@@ -86,4 +88,215 @@ func TestQueryBalance(t *testing.T) {
 	assert.Equal(t, []byte(jsonstr), res.Value)
 	assert.Equal(t, req.Data, res.Key)
 	assert.Equal(t, string(jsonstr), res.Log)
+}
+
+func TestQueryParcel(t *testing.T) {
+	db := tdb.NewMemDB()
+	app := NewAMOApplication(db)
+
+	// populate db store
+	addrbin, _ := hex.DecodeString("7CECB223B976F27D77B0E03E95602DABCC28D876")
+	addr := crypto.Address(addrbin)
+	parcelID := cmn.RandBytes(32)
+	parcelID[31] = 0xFF
+
+	parcel := types.ParcelValue{
+		Owner:addr,
+		Custody: cmn.RandBytes(32),
+		Info: []byte("This is test parcel value"),
+	}
+
+	app.store.SetParcel(parcelID, &parcel)
+
+	wrongParcelID := cmn.RandBytes(32)
+	wrongParcelID[31] = 0xBB
+
+	var req abci.RequestQuery
+	var res abci.ResponseQuery
+	var jsonstr []byte
+
+	// errors
+	req = abci.RequestQuery{Path: "/parcel"}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeNoKey, res.Code)
+
+	// TODO: check this after parcel type implemented
+	/*
+	req = abci.RequestQuery{Path: "/parcel", Data: []byte("f8das")}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeBadKey, res.Code)
+	*/
+
+	req = abci.RequestQuery{Path: "/parcel", Data: wrongParcelID}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeNoMatch, res.Code)
+	assert.Nil(t, res.Value)
+	assert.Len(t, res.Log, 0)
+
+	// query
+	req = abci.RequestQuery{Path: "/parcel", Data: parcelID}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeOK, res.Code)
+	jsonstr, _ = json.Marshal(parcel)
+	assert.Equal(t, []byte(jsonstr), res.Value)
+	assert.Equal(t, req.Data, res.Key)
+	assert.Equal(t, string(jsonstr), res.Log)
+}
+
+func TestQueryRequest(t *testing.T) {
+	db := tdb.NewMemDB()
+	app := NewAMOApplication(db)
+
+	// populate db store
+	addrbin, _ := hex.DecodeString("7CECB223B976F27D77B0E03E95602DABCC28D876")
+	addr := crypto.Address(addrbin)
+	parcelID := cmn.RandBytes(32)
+	parcelID[31] = 0xFF
+
+	request := types.RequestValue{
+		Payment: 400,
+	}
+
+	app.store.SetRequest(addr, parcelID, &request)
+
+	wrongParcelID := cmn.RandBytes(32)
+	wrongParcelID[31] = 0xBB
+	wrongAddr := p256.GenPrivKey().PubKey().Address()
+	wrongAddr[19] = 0xFF
+
+	var req abci.RequestQuery
+	var res abci.ResponseQuery
+	var jsonstr []byte
+
+	// errors
+	req = abci.RequestQuery{Path: "/request"}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeNoKey, res.Code)
+
+	// TODO: check this after parcel type implemented
+	/*
+	req = abci.RequestQuery{Path: "/parcel", Data: []byte("f8das")}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeBadKey, res.Code)
+	*/
+
+	jsonstr, _ = json.Marshal(addr)
+	req = abci.RequestQuery{Path: "/request", Data: jsonstr}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeBadKey, res.Code)
+	assert.Nil(t, res.Value)
+	assert.Len(t, res.Log, 0)
+
+	jsonstr, _ = json.Marshal(parcelID)
+	req = abci.RequestQuery{Path: "/request", Data: jsonstr}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeBadKey, res.Code)
+	assert.Nil(t, res.Value)
+	assert.Len(t, res.Log, 0)
+
+	var keyMap = map[string]cmn.HexBytes{
+		"buyer": addr,
+		"target": parcelID,
+	}
+
+	// query
+	key, _ := json.Marshal(keyMap)
+	req = abci.RequestQuery{Path: "/request", Data: key}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeOK, res.Code)
+	jsonstr, _ = json.Marshal(request)
+	assert.Equal(t, []byte(jsonstr), res.Value)
+	assert.Equal(t, req.Data, res.Key)
+	assert.Equal(t, string(jsonstr), res.Log)
+
+	keyMap["buyer"] = wrongAddr
+	key, _ = json.Marshal(keyMap)
+	req = abci.RequestQuery{Path: "/request", Data: key}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeNoMatch, res.Code)
+
+	delete(keyMap, "buyer")
+	key, _ = json.Marshal(keyMap)
+	req = abci.RequestQuery{Path: "/request", Data: key}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeBadKey, res.Code)
+}
+
+func TestQueryUsage(t *testing.T) {
+	db := tdb.NewMemDB()
+	app := NewAMOApplication(db)
+
+	// populate db store
+	addrbin, _ := hex.DecodeString("7CECB223B976F27D77B0E03E95602DABCC28D876")
+	addr := crypto.Address(addrbin)
+	parcelID := cmn.RandBytes(32)
+	parcelID[31] = 0xFF
+
+	usage := types.UsageValue{
+		Custody: cmn.RandBytes(32),
+	}
+
+	app.store.SetUsage(addr, parcelID, &usage)
+
+	wrongParcelID := cmn.RandBytes(32)
+	wrongParcelID[31] = 0xBB
+	wrongAddr := p256.GenPrivKey().PubKey().Address()
+	wrongAddr[19] = 0xFF
+
+	var req abci.RequestQuery
+	var res abci.ResponseQuery
+	var jsonstr []byte
+
+	// errors
+	req = abci.RequestQuery{Path: "/usage"}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeNoKey, res.Code)
+
+	// TODO: check this after parcel type implemented
+	/*
+	req = abci.RequestQuery{Path: "/parcel", Data: []byte("f8das")}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeBadKey, res.Code)
+	*/
+
+	jsonstr, _ = json.Marshal(addr)
+	req = abci.RequestQuery{Path: "/usage", Data: jsonstr}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeBadKey, res.Code)
+	assert.Nil(t, res.Value)
+	assert.Len(t, res.Log, 0)
+
+	jsonstr, _ = json.Marshal(parcelID)
+	req = abci.RequestQuery{Path: "/usage", Data: jsonstr}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeBadKey, res.Code)
+	assert.Nil(t, res.Value)
+	assert.Len(t, res.Log, 0)
+
+	var keyMap = map[string]cmn.HexBytes{
+		"buyer": addr,
+		"target": parcelID,
+	}
+
+	// query
+	key, _ := json.Marshal(keyMap)
+	req = abci.RequestQuery{Path: "/usage", Data: key}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeOK, res.Code)
+	jsonstr, _ = json.Marshal(usage)
+	assert.Equal(t, []byte(jsonstr), res.Value)
+	assert.Equal(t, req.Data, res.Key)
+	assert.Equal(t, string(jsonstr), res.Log)
+
+	keyMap["buyer"] = wrongAddr
+	key, _ = json.Marshal(keyMap)
+	req = abci.RequestQuery{Path: "/usage", Data: key}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeNoMatch, res.Code)
+
+	delete(keyMap, "buyer")
+	key, _ = json.Marshal(keyMap)
+	req = abci.RequestQuery{Path: "/usage", Data: key}
+	res = app.Query(req)
+	assert.Equal(t, code.QueryCodeBadKey, res.Code)
 }


### PR DESCRIPTION
Query for parcel-related data

## Parcel
key: target
## Request
key: { buyer, target } // use object for key
## Usage
key: { buyer, target } // use object for key