### PR TITLE
Feature/113 cleveldb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,12 +15,9 @@
 vendor
 
 # output binary files
-/amocli
 /amod
-/tendermint
 
 # docker-related files
-DOCKER/amocli
 DOCKER/amod
 DOCKER/tendermint
 /docker-compose.yml

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -1,5 +1,35 @@
 # vim: set expandtab:
-FROM alpine:3.7
+
+#### builder image
+
+FROM golang:1.12-alpine3.9
+
+# tools
+RUN apk add bash git make gcc g++
+
+# libs
+RUN apk add snappy
+
+RUN mkdir /src
+WORKDIR /src
+
+# leveldb
+RUN wget https://github.com/google/leveldb/archive/v1.20.tar.gz
+RUN tar zxvf v1.20.tar.gz && make -C leveldb-1.20
+RUN cp -a leveldb-1.20/include/leveldb /usr/include/
+RUN cp -a leveldb-1.20/out-shared/libleveldb.so* /usr/lib/
+
+# tendermint
+RUN git clone -b v0.32.3 https://github.com/tendermint/tendermint
+RUN make -C tendermint get_tools && make -C tendermint build_c
+
+# amod
+COPY .. amod/
+RUN make build
+
+#### runner image
+
+FROM alpine:3.9
 
 ENV AMOHOME /amo
 ENV TMHOME /tendermint
@@ -7,7 +37,10 @@ ENV TMHOME /tendermint
 VOLUME [ $AMOHOME ]
 VOLUME [ $TMHOME ]
 
-COPY tendermint amod /usr/bin/
+#COPY tendermint amod /usr/bin/
+COPY --from=0 /usr/lib/libleveldb.so* /usr/lib/
+COPY --from=0 /src/tendermint/build/tendermint /usr/bin/
+COPY --from=0 /src/amod/amod /usr/bin/
 COPY run_node.sh config/* /
 
 WORKDIR /

--- a/DOCKER/config/config.toml.in
+++ b/DOCKER/config/config.toml.in
@@ -27,7 +27,7 @@ fast_sync = true
 #   - EXPERIMENTAL
 #   - may be faster is some use-cases (random reads - indexer)
 #   - use boltdb build tag (go build -tags boltdb)
-db_backend = "goleveldb"
+db_backend = "cleveldb"
 
 # Database directory
 db_dir = "data"

--- a/DOCKER/run_node.sh
+++ b/DOCKER/run_node.sh
@@ -17,5 +17,8 @@ fi
 
 /usr/bin/tendermint init
 
-/usr/bin/amod run &
-/usr/bin/tendermint node
+# TODO: ensure directory
+mkdir -p /amo/data
+# TODO: take homedir argument
+cd /amo && /usr/bin/amod run &
+/usr/bin/tendermint --home /tendermint node

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY Makefile go.mod go.sum amoabci/
 COPY cmd amoabci/cmd
 COPY amo amoabci/amo
 COPY crypto amoabci/crypto
-RUN make -C amoabci build
+RUN make -C amoabci build_c
 
 #### runner image
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,17 +35,21 @@ RUN make -C amoabci build
 
 FROM alpine:3.9
 
-ENV AMOHOME /amo
-ENV TMHOME /tendermint
-
-VOLUME [ $AMOHOME ]
-VOLUME [ $TMHOME ]
+# tools & libs
+RUN apk add bash snappy
 
 #COPY tendermint amod /usr/bin/
 COPY --from=0 /usr/lib/libleveldb.so* /usr/lib/
+COPY --from=0 /usr/lib/libgcc_s.so* /usr/lib/
+COPY --from=0 /usr/lib/libstdc++.so* /usr/lib/
 COPY --from=0 /src/tendermint/build/tendermint /usr/bin/
 COPY --from=0 /src/amoabci/amod /usr/bin/
-COPY DOCKER/run_node.sh config/* /
+COPY DOCKER/run_node.sh DOCKER/config/* /
+
+ENV AMOHOME /amo
+ENV TMHOME /tendermint
+VOLUME [ $AMOHOME ]
+VOLUME [ $TMHOME ]
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,12 @@ RUN git clone -b v0.32.3 https://github.com/tendermint/tendermint
 RUN make -C tendermint get_tools && make -C tendermint build_c
 
 # amod
-COPY .. amod/
-RUN make build
+RUN mkdir -p amoabci
+COPY Makefile go.mod go.sum amoabci/
+COPY cmd amoabci/cmd
+COPY amo amoabci/amo
+COPY crypto amoabci/crypto
+RUN make -C amoabci build
 
 #### runner image
 
@@ -40,8 +44,8 @@ VOLUME [ $TMHOME ]
 #COPY tendermint amod /usr/bin/
 COPY --from=0 /usr/lib/libleveldb.so* /usr/lib/
 COPY --from=0 /src/tendermint/build/tendermint /usr/bin/
-COPY --from=0 /src/amod/amod /usr/bin/
-COPY run_node.sh config/* /
+COPY --from=0 /src/amoabci/amod /usr/bin/
+COPY DOCKER/run_node.sh config/* /
 
 WORKDIR /
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,17 @@ build:
 	@echo "--> Building amo daemon (amod)"
 	$(BUILDENV) go build -tags "cleveldb" ./cmd/amod
 
+# compatibility target
+build_c:
+	@echo "--> Building amo daemon (amod)"
+	$(BUILDENV) go build -tags "cleveldb" ./cmd/amod
+
 install:
+	@echo "--> Installing amo daemon (amod)"
+	$(BUILDENV) go install -tags "cleveldb" ./cmd/amod
+
+# compatibility target
+install_c:
 	@echo "--> Installing amo daemon (amod)"
 	$(BUILDENV) go install -tags "cleveldb" ./cmd/amod
 
@@ -30,7 +40,7 @@ test:
 	go test ./...
 
 docker:
-	docker build -t amolabs/amod DOCKER
+	docker build -t amolabs/amod .
 
 clean:
 	rm -f amod

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ tags: $(GOSRCS)
 
 build:
 	@echo "--> Building amo daemon (amod)"
-	$(BUILDENV) go build -tags "cleveldb" ./cmd/amod
+	$(BUILDENV) go build ./cmd/amod
 
 # compatibility target
 build_c:
@@ -29,7 +29,7 @@ build_c:
 
 install:
 	@echo "--> Installing amo daemon (amod)"
-	$(BUILDENV) go install -tags "cleveldb" ./cmd/amod
+	$(BUILDENV) go install ./cmd/amod
 
 # compatibility target
 install_c:
@@ -37,6 +37,9 @@ install_c:
 	$(BUILDENV) go install -tags "cleveldb" ./cmd/amod
 
 test:
+	go test ./...
+
+test_c:
 	go test -tags "cleveldb" ./...
 
 docker:

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test:
 tendermint:
 	-git clone https://github.com/tendermint/tendermint $(TMPATH)
 	cd $(TMPATH); git checkout v0.32.3
-	make -C $(TMPATH) tools
+	make -C $(TMPATH) get_tools
 	make -C $(TMPATH) build-linux
 	cp $(TMPATH)/build/tendermint ./
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 all: build
 
 GO := $(shell command -v go 2> /dev/null)
-FS := /
 # go source code files
 GOSRCS=$(shell find . -name \*.go)
 BUILDENV=CGO_ENABLED=0
@@ -16,33 +15,8 @@ ifneq ($(TARGET),)
   BUILDENV += GOOS=$(TARGET)
 endif
 
-GOPATH ?= $(shell $(GO) env GOPATH)
-GITHUBDIR := $(GOPATH)$(FS)src$(FS)github.com
-TMPATH=$(GOPATH)/src/github.com/tendermint/tendermint
-
-go_get = $(if $(findstring Windows_NT,$(OS)),\
-IF NOT EXIST $(GITHUBDIR)$(FS)$(1)$(FS) ( mkdir $(GITHUBDIR)$(FS)$(1) ) else (cd .) &\
-IF NOT EXIST $(GITHUBDIR)$(FS)$(1)$(FS)$(2)$(FS) ( cd $(GITHUBDIR)$(FS)$(1) && git clone https://github.com/$(1)/$(2) ) else (cd .) &\
-,\
-mkdir -p $(GITHUBDIR)$(FS)$(1) &&\
-(test ! -d $(GITHUBDIR)$(FS)$(1)$(FS)$(2) && cd $(GITHUBDIR)$(FS)$(1) && git clone https://github.com/$(1)/$(2)) || true &&\
-)\
-cd $(GITHUBDIR)$(FS)$(1)$(FS)$(2) && git fetch origin && git checkout -q $(3)
-
-go_install = $(call go_get,$(1),$(2),$(3)) && cd $(GITHUBDIR)$(FS)$(1)$(FS)$(2) && $(GO) install
-
 tags: $(GOSRCS)
 	gotags -R -f tags .
-
-#v2.0.11
-$(GOPATH)/bin/gometalinter:
-	$(call go_install,alecthomas,gometalinter,17a7ffa42374937bfecabfb8d2efbd4db0c26741)
-
-$(GOPATH)/bin/statik:
-	$(call go_install,rakyll,statik,v0.1.5)
-
-$(GOPATH)/bin/goimports:
-	go get golang.org/x/tools/cmd/goimports
 
 build:
 	@echo "--> Building amo daemon (amod)"
@@ -55,17 +29,8 @@ install:
 test:
 	go test ./...
 
-tendermint:
-	-git clone https://github.com/tendermint/tendermint $(TMPATH)
-	cd $(TMPATH); git checkout v0.32.3
-	make -C $(TMPATH) get_tools
-	make -C $(TMPATH) build-linux
-	cp $(TMPATH)/build/tendermint ./
-
-docker: tendermint
-	$(MAKE) TARGET=linux build
-	cp -f amod tendermint DOCKER/
+docker:
 	docker build -t amolabs/amod DOCKER
 
 clean:
-	rm -f amod tendermint
+	rm -f amod

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ install_c:
 	$(BUILDENV) go install -tags "cleveldb" ./cmd/amod
 
 test:
-	go test ./...
+	go test -tags "cleveldb" ./...
 
 docker:
 	docker build -t amolabs/amod .

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 GO := $(shell command -v go 2> /dev/null)
 # go source code files
 GOSRCS=$(shell find . -name \*.go)
-BUILDENV=CGO_ENABLED=0
+BUILDENV=CGO_ENABLED=1
 
 ifeq ($(GO),)
   $(error could not find go. Is it in PATH? $(GO))
@@ -20,11 +20,11 @@ tags: $(GOSRCS)
 
 build:
 	@echo "--> Building amo daemon (amod)"
-	$(BUILDENV) go build ./cmd/amod
+	$(BUILDENV) go build -tags "cleveldb" ./cmd/amod
 
 install:
 	@echo "--> Installing amo daemon (amod)"
-	$(BUILDENV) go install ./cmd/amod
+	$(BUILDENV) go install -tags "cleveldb" ./cmd/amod
 
 test:
 	go test ./...

--- a/README.ko.md
+++ b/README.ko.md
@@ -28,7 +28,10 @@ TBA
 * [golang](https://golang.org/dl/)
   * 경우에 따라서 `GOPATH`와 `GOBIN` 환경변수를 수동으로 설정해 줘야 할 수
 	있다. 이후 더 진행하기 전에 이 변수들을 확인하도록 한다.
-* [golang/dep](https://golang.github.io/dep/docs/installation.html)
+* [leveldb](https://github.com/google/leveldb)
+  * Debian이나 Ubuntu 리눅수의 경우에는 `libleveldb-dev` 패키지를 설치한다.
+  * 컴파일하는 서버와 실행하는 서버가 다를 경우 실행하는 서버에는
+	`libleveldb1v5` 패키지를 설치한다.
 
 데몬 프로그램들을 docker 컨테이너에서 실행하거나 docker를 필요로 하는
 테스트들을 실행하기 위해서는 다음을 설치한다:
@@ -48,7 +51,7 @@ cd $GOPATH/src/github.com/tendermint
 git clone https://github.com/tendermint/tendermint
 cd tendermint
 make get_tools
-make install
+make install_c
 ```
 
 ### amod 설치

--- a/README.ko.md
+++ b/README.ko.md
@@ -39,7 +39,7 @@ TBA
 AMO 블록체인을 위한 ABCI 앱을 실행하려면 같은 호스트에서
 [tendermint](https://github.com/tendermint/tendermint) 데몬이 실행되고 있어야
 한다. 따라서 tendermint를 먼저 설치하도록 한다. 현재 버전의 AMO ABCI 앱은
-tendermint v0.31.7이 필요하다.
+tendermint v0.32.3이 필요하다.
 
 다음 명령을 실행해서 tendermint 데몬을 설치한다:
 ```bash
@@ -48,7 +48,6 @@ cd $GOPATH/src/github.com/tendermint
 git clone https://github.com/tendermint/tendermint
 cd tendermint
 make get_tools
-make get_vendor_deps
 make install
 ```
 
@@ -60,7 +59,6 @@ cd $GOPATH/src/github.com/amolabs
 git clone https://github.com/amolabs/amoabci
 cd amoabci
 make get_tools
-make get_vendor_deps
 make install
 ```
 
@@ -186,7 +184,6 @@ cd $GOPATH/src/github.com/tendermint
 git clone https://github.com/tendermint/tendermint
 cd tendermint
 make get_tools
-make get_vendor_deps
 make build-linux
 cp tendermint $GOPATH/src/github.com/amolabs/amoabci/
 ```
@@ -198,7 +195,6 @@ cd $GOPATH/src/github.com/amolabs
 git clone https://github.com/amolabs/amoabci
 cd amoabci
 make get_tools
-make get_vendor_deps
 make docker
 ```
 이미지는 `amolabs/amod:latest`로 태그된다. 이 이미지는 `tendermint`와 `amod`를

--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ To build from source, you need to install the followings:
 * [golang](https://golang.org/dl/)
   * In some cases, you need to set `GOPATH` and `GOBIN` environment variables
 	manually. Check these variables before you proceed.
-* [golang/dep](https://golang.github.io/dep/docs/installation.html)
+* [leveldb](https://github.com/google/leveldb)
+  * For Debian or Ubuntu linux, you can install `libleveldb-dev` package.
+  * In case you use different servers for building and production, install
+	`libleveldb1v5` package in the production server.
 
 If you want to run daemons in a docker container or execute some tests
 requiring docker, you need install the following:
@@ -48,7 +51,7 @@ cd $GOPATH/src/github.com/tendermint
 git clone https://github.com/tendermint/tendermint
 cd tendermint
 make get_tools
-make install
+make install_c
 ```
 
 ### Install amod

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ requiring docker, you need install the following:
 ABCI app for AMO blockchain requires a
 [tendermint](https://github.com/tendermint/tendermint) daemon running in the
 same host. So, we need to install tendermint first. Current version of AMO ABCI
-app requires tendermint v0.31.7.
+app requires tendermint v0.32.3.
 
 Run the following commands to install tendermint daemon:
 ```bash
@@ -48,7 +48,6 @@ cd $GOPATH/src/github.com/tendermint
 git clone https://github.com/tendermint/tendermint
 cd tendermint
 make get_tools
-make get_vendor_deps
 make install
 ```
 
@@ -60,7 +59,6 @@ cd $GOPATH/src/github.com/amolabs
 git clone https://github.com/amolabs/amoabci
 cd amoabci
 make get_tools
-make get_vendor_deps
 make install
 ```
 
@@ -188,7 +186,6 @@ git clone https://github.com/tendermint/tendermint
 cd tendermint
 git checkout v0.31.7
 make get_tools
-make get_vendor_deps
 make build-linux
 cp build/tendermint $GOPATH/src/github.com/amolabs/amoabci/
 ```
@@ -200,7 +197,6 @@ cd $GOPATH/src/github.com/amolabs
 git clone https://github.com/amolabs/amoabci
 cd amoabci
 make get_tools
-make get_vendor_deps
 make docker
 ```
 The image will be tagged as `amolabs/amod:latest`. This image include both of

--- a/amo/store/db_proxy.go
+++ b/amo/store/db_proxy.go
@@ -1,0 +1,9 @@
+// +build !cleveldb
+
+package store
+
+import tmdb "github.com/tendermint/tm-db"
+
+func NewDBProxy(name, dir string) (tmdb.DB, error) {
+	return tmdb.NewGoLevelDB(name, dir)
+}

--- a/amo/store/db_proxy_c.go
+++ b/amo/store/db_proxy_c.go
@@ -1,0 +1,9 @@
+// +build cleveldb
+
+package store
+
+import tmdb "github.com/tendermint/tm-db"
+
+func NewDBProxy(name, dir string) (tmdb.DB, error) {
+	return tmdb.NewCLevelDB(name, dir)
+}

--- a/amo/store/store.go
+++ b/amo/store/store.go
@@ -66,7 +66,7 @@ func (s Store) Purge() error {
 	var itr tmdb.Iterator
 
 	// stateDB
-	itr = s.stateDB.Iterator([]byte{}, []byte(nil))
+	itr = s.stateDB.Iterator(nil, nil)
 
 	// TODO: cannot guarantee in multi-thread environment
 	// need some sync mechanism
@@ -81,7 +81,7 @@ func (s Store) Purge() error {
 	itr.Close()
 
 	// indexDB
-	itr = s.indexDB.Iterator([]byte{}, []byte(nil))
+	itr = s.indexDB.Iterator(nil, nil)
 
 	// TODO: cannot guarantee in multi-thread environment
 	// need some sync mechanism

--- a/amo/store/store_test.go
+++ b/amo/store/store_test.go
@@ -60,6 +60,20 @@ func tearDown(t *testing.T) {
 
 // tests
 
+func TestPurge(t *testing.T) {
+	setUp(t)
+	defer tearDown(t)
+	sdb, err := tmdb.NewCLevelDB("state", testRoot)
+	idb, err := tmdb.NewCLevelDB("index", testRoot)
+	assert.NoError(t, err)
+
+	s := NewStore(sdb, idb)
+	assert.NotNil(t, s)
+
+	err = s.Purge()
+	assert.NoError(t, err)
+}
+
 func TestBalance(t *testing.T) {
 	s := NewStore(tmdb.NewMemDB(), tmdb.NewMemDB())
 	testAddr := p256.GenPrivKey().PubKey().Address()

--- a/amo/store/store_test.go
+++ b/amo/store/store_test.go
@@ -63,8 +63,8 @@ func tearDown(t *testing.T) {
 func TestPurge(t *testing.T) {
 	setUp(t)
 	defer tearDown(t)
-	sdb, err := tmdb.NewCLevelDB("state", testRoot)
-	idb, err := tmdb.NewCLevelDB("index", testRoot)
+	sdb, err := NewDBProxy("state", testRoot)
+	idb, err := NewDBProxy("index", testRoot)
 	assert.NoError(t, err)
 
 	s := NewStore(sdb, idb)

--- a/cmd/amod/cmd/run.go
+++ b/cmd/amod/cmd/run.go
@@ -33,11 +33,11 @@ func initApp() error {
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 	appLogger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 	// TODO: do not use hard-coded value. use value from configuration.
-	db, err := tmdb.NewGoLevelDB("store", "data/state")
+	db, err := tmdb.NewCLevelDB("store", "data/state")
 	if err != nil {
 		return err
 	}
-	index, err := tmdb.NewGoLevelDB("index", "data/index")
+	index, err := tmdb.NewCLevelDB("index", "data/index")
 	if err != nil {
 		return err
 	}

--- a/cmd/amod/cmd/run.go
+++ b/cmd/amod/cmd/run.go
@@ -33,11 +33,11 @@ func initApp() error {
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 	appLogger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 	// TODO: do not use hard-coded value. use value from configuration.
-	db, err := tmdb.NewCLevelDB("store", "data/state")
+	db, err := tmdb.NewCLevelDB("store", "data")
 	if err != nil {
 		return err
 	}
-	index, err := tmdb.NewCLevelDB("index", "data/index")
+	index, err := tmdb.NewCLevelDB("index", "data")
 	if err != nil {
 		return err
 	}

--- a/cmd/amod/cmd/run.go
+++ b/cmd/amod/cmd/run.go
@@ -7,9 +7,9 @@ import (
 	"github.com/tendermint/tendermint/abci/server"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/libs/log"
-	tmdb "github.com/tendermint/tm-db"
 
 	"github.com/amolabs/amoabci/amo"
+	"github.com/amolabs/amoabci/amo/store"
 )
 
 /* Commands (expected hierarchy)
@@ -33,11 +33,11 @@ func initApp() error {
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 	appLogger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 	// TODO: do not use hard-coded value. use value from configuration.
-	db, err := tmdb.NewCLevelDB("store", "data")
+	db, err := store.NewDBProxy("store", "data")
 	if err != nil {
 		return err
 	}
-	index, err := tmdb.NewCLevelDB("index", "data")
+	index, err := store.NewDBProxy("index", "data")
 	if err != nil {
 		return err
 	}

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 h1:5Beo0mZN8dRzgrMMkDp0jc8YXQKx9DiJ2k1dkvGsn5A=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/test_script/all.sh
+++ b/test_script/all.sh
@@ -33,9 +33,6 @@ NODENUM=6
 
 AMO100=100000000000000000000
 
-echo "get vendor deps"
-make get_vendor_deps
-
 echo "build docker image"
 make docker
 


### PR DESCRIPTION
- build binaries for a docker image in a docker container since it is tricky to prepare a cross-complied leveldb library in a build machine
- move Dockerfile from DOCKER/ to src root
- use cleveldb when build tag "cleveldb" is given
- double variants for each of build, install and test targets

closes #114 