### PR TITLE
Prevent doubling stake

### DIFF
--- a/amo/code/code.go
+++ b/amo/code/code.go
@@ -5,6 +5,7 @@ const (
 	TxCodeBadParam
 	TxCodeTooOldTx
 	TxCodeAlreadyProcessedTx
+	TxCodeUnavailableAmount
 	TxCodeNotEnoughBalance
 	TxCodeSelfTransaction
 	TxCodePermissionDenied

--- a/amo/code/code.go
+++ b/amo/code/code.go
@@ -5,6 +5,7 @@ const (
 	TxCodeBadParam
 	TxCodeTooOldTx
 	TxCodeAlreadyProcessedTx
+	TxCodeInvalidAmount
 	TxCodeNotEnoughBalance
 	TxCodeSelfTransaction
 	TxCodePermissionDenied

--- a/amo/tx/delegate.go
+++ b/amo/tx/delegate.go
@@ -54,6 +54,11 @@ func (t *TxDelegate) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
+	// check balance
+	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+		return code.TxCodeInvalidAmount, "invalid amount", nil
+	}
+
 	// check minimum staking unit first
 	tmp := new(types.Currency)
 	checkUnit, err := new(types.Currency).SetString(ConfigMinStakingUnit, 10)
@@ -66,7 +71,6 @@ func (t *TxDelegate) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeImproperStakeAmount, "improper stake amount", nil
 	}
 
-	// check balance
 	balance := store.GetBalance(t.GetSender(), false)
 	if balance.LessThan(&txParam.Amount) {
 		return code.TxCodeNotEnoughBalance, "not enough balance", nil

--- a/amo/tx/delegate.go
+++ b/amo/tx/delegate.go
@@ -54,12 +54,11 @@ func (t *TxDelegate) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
-	// check balance
-	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+	if !txParam.Amount.GreaterThan(zero) {
 		return code.TxCodeInvalidAmount, "invalid amount", nil
 	}
 
-	// check minimum staking unit first
+	// check minimum staking unit
 	tmp := new(types.Currency)
 	checkUnit, err := new(types.Currency).SetString(ConfigMinStakingUnit, 10)
 	if err != nil {

--- a/amo/tx/delegate.go
+++ b/amo/tx/delegate.go
@@ -54,7 +54,7 @@ func (t *TxDelegate) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
-	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+	if !txParam.Amount.GreaterThan(zero) {
 		return code.TxCodeUnavailableAmount, "unavailable amount", nil
 	}
 

--- a/amo/tx/delegate.go
+++ b/amo/tx/delegate.go
@@ -54,6 +54,10 @@ func (t *TxDelegate) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
+	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+		return code.TxCodeUnavailableAmount, "unavailable amount", nil
+	}
+
 	balance := store.GetBalance(t.GetSender(), false)
 	if balance.LessThan(&txParam.Amount) {
 		return code.TxCodeNotEnoughBalance, "not enough balance", nil

--- a/amo/tx/retract.go
+++ b/amo/tx/retract.go
@@ -45,6 +45,10 @@ func (t *TxRetract) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
+	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+		return code.TxCodeUnavailableAmount, "unavailable amount", nil
+	}
+
 	delegate := store.GetDelegate(t.GetSender(), false)
 	if delegate == nil {
 		return code.TxCodeDelegateNotFound, "delegate not found", nil

--- a/amo/tx/retract.go
+++ b/amo/tx/retract.go
@@ -45,7 +45,7 @@ func (t *TxRetract) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
-	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+	if !txParam.Amount.GreaterThan(zero) {
 		return code.TxCodeUnavailableAmount, "unavailable amount", nil
 	}
 

--- a/amo/tx/retract.go
+++ b/amo/tx/retract.go
@@ -45,7 +45,7 @@ func (t *TxRetract) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
-	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+	if !txParam.Amount.GreaterThan(zero) {
 		return code.TxCodeInvalidAmount, "invalid amount", nil
 	}
 

--- a/amo/tx/retract.go
+++ b/amo/tx/retract.go
@@ -45,6 +45,10 @@ func (t *TxRetract) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
+	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+		return code.TxCodeInvalidAmount, "invalid amount", nil
+	}
+
 	delegate := store.GetDelegate(t.GetSender(), false)
 	if delegate == nil {
 		return code.TxCodeDelegateNotFound, "delegate not found", nil

--- a/amo/tx/stake.go
+++ b/amo/tx/stake.go
@@ -52,8 +52,7 @@ func (t *TxStake) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
-	// check balance
-	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+	if !txParam.Amount.GreaterThan(zero) {
 		return code.TxCodeInvalidAmount, "invalid amount", nil
 	}
 

--- a/amo/tx/stake.go
+++ b/amo/tx/stake.go
@@ -1,7 +1,6 @@
 package tx
 
 import (
-	"bytes"
 	"encoding/json"
 
 	"github.com/tendermint/tendermint/crypto/ed25519"
@@ -53,25 +52,24 @@ func (t *TxStake) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
+	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+		return code.TxCodeUnavailableAmount, "unavailable amount", nil
+	}
+
 	balance := store.GetBalance(t.GetSender(), false)
 	if balance.LessThan(&txParam.Amount) {
 		return code.TxCodeNotEnoughBalance, "not enough balance", nil
 	}
 
 	balance.Sub(&txParam.Amount)
-	stake := store.GetStake(t.GetSender(), false)
-	if stake == nil {
-		var k ed25519.PubKeyEd25519
-		copy(k[:], txParam.Validator)
-		stake = &types.Stake{
-			Amount:    txParam.Amount,
-			Validator: k,
-		}
-	} else if bytes.Equal(stake.Validator[:], txParam.Validator[:]) {
-		stake.Amount.Add(&txParam.Amount)
-	} else {
-		return code.TxCodePermissionDenied, "validator key mismatch", nil
+
+	var k ed25519.PubKeyEd25519
+	copy(k[:], txParam.Validator)
+	stake := &types.Stake{
+		Amount:    txParam.Amount,
+		Validator: k,
 	}
+
 	err = store.SetLockedStake(t.GetSender(), stake, int64(ConfigLockupPeriod))
 	if err != nil {
 		switch err {
@@ -87,6 +85,8 @@ func (t *TxStake) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 			return code.TxCodeUnknown, err.Error(), nil
 		}
 	}
+
 	store.SetBalance(t.GetSender(), balance)
+
 	return code.TxCodeOK, "ok", nil
 }

--- a/amo/tx/stake.go
+++ b/amo/tx/stake.go
@@ -1,7 +1,6 @@
 package tx
 
 import (
-	"bytes"
 	"encoding/json"
 
 	"github.com/tendermint/tendermint/crypto/ed25519"
@@ -53,6 +52,11 @@ func (t *TxStake) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
+	// check balance
+	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+		return code.TxCodeInvalidAmount, "invalid amount", nil
+	}
+
 	// check minimum staking unit first
 	tmp := new(types.Currency)
 	checkUnit, err := new(types.Currency).SetString(ConfigMinStakingUnit, 10)
@@ -65,26 +69,20 @@ func (t *TxStake) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeImproperStakeAmount, "improper stake amount", nil
 	}
 
-	// check balance
 	balance := store.GetBalance(t.GetSender(), false)
 	if balance.LessThan(&txParam.Amount) {
 		return code.TxCodeNotEnoughBalance, "not enough balance", nil
 	}
 
 	balance.Sub(&txParam.Amount)
-	stake := store.GetStake(t.GetSender(), false)
-	if stake == nil {
-		var k ed25519.PubKeyEd25519
-		copy(k[:], txParam.Validator)
-		stake = &types.Stake{
-			Amount:    txParam.Amount,
-			Validator: k,
-		}
-	} else if bytes.Equal(stake.Validator[:], txParam.Validator[:]) {
-		stake.Amount.Add(&txParam.Amount)
-	} else {
-		return code.TxCodePermissionDenied, "validator key mismatch", nil
+
+	var k ed25519.PubKeyEd25519
+	copy(k[:], txParam.Validator)
+	stake := &types.Stake{
+		Amount:    txParam.Amount,
+		Validator: k,
 	}
+
 	err = store.SetLockedStake(t.GetSender(), stake, int64(ConfigLockupPeriod))
 	if err != nil {
 		switch err {
@@ -100,6 +98,8 @@ func (t *TxStake) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 			return code.TxCodeUnknown, err.Error(), nil
 		}
 	}
+
 	store.SetBalance(t.GetSender(), balance)
+
 	return code.TxCodeOK, "ok", nil
 }

--- a/amo/tx/stake.go
+++ b/amo/tx/stake.go
@@ -52,7 +52,7 @@ func (t *TxStake) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
-	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+	if !txParam.Amount.GreaterThan(zero) {
 		return code.TxCodeUnavailableAmount, "unavailable amount", nil
 	}
 

--- a/amo/tx/transfer.go
+++ b/amo/tx/transfer.go
@@ -54,7 +54,7 @@ func (t *TxTransfer) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
-	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+	if !txParam.Amount.GreaterThan(zero) {
 		return code.TxCodeUnavailableAmount, "unavailable amount", nil
 	}
 

--- a/amo/tx/transfer.go
+++ b/amo/tx/transfer.go
@@ -54,6 +54,10 @@ func (t *TxTransfer) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
+	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+		return code.TxCodeUnavailableAmount, "unavailable amount", nil
+	}
+
 	fromBalance := store.GetBalance(t.GetSender(), false)
 	if fromBalance.LessThan(&txParam.Amount) {
 		return code.TxCodeNotEnoughBalance, "not enough balance", nil

--- a/amo/tx/transfer.go
+++ b/amo/tx/transfer.go
@@ -56,6 +56,10 @@ func (t *TxTransfer) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
+	if !txParam.Amount.GreaterThan(zero) {
+		return code.TxCodeInvalidAmount, "invalid amount", nil
+	}
+
 	udc := []byte(nil)
 	if len(txParam.UDC) > 0 {
 		udc = txParam.UDC

--- a/amo/tx/tx.go
+++ b/amo/tx/tx.go
@@ -19,12 +19,13 @@ const (
 )
 
 var (
-	c = elliptic.P256()
+	// config values from the app
+	ConfigLockupPeriod = defaultLockupPeriod
 )
 
 var (
-	// config values from the app
-	ConfigLockupPeriod = defaultLockupPeriod
+	c    = elliptic.P256()
+	zero = new(types.Currency).Set(0)
 )
 
 type Signature struct {

--- a/amo/tx/tx.go
+++ b/amo/tx/tx.go
@@ -21,14 +21,13 @@ const (
 )
 
 var (
-	c = elliptic.P256()
-)
-
-var (
 	// config values from the app
 	ConfigLockupPeriod   = defaultLockupPeriod
 	ConfigMinStakingUnit = defaultMinStakingUnit
 	ConfigMaxValidators  = defaultMaxValidators
+
+	c    = elliptic.P256()
+	zero = new(types.Currency).Set(0)
 )
 
 type Signature struct {

--- a/amo/tx/tx_test.go
+++ b/amo/tx/tx_test.go
@@ -565,26 +565,29 @@ func TestNonValidTransfer(t *testing.T) {
 	s := store.NewStore(tmdb.NewMemDB(), tmdb.NewMemDB(), tmdb.NewMemDB(), tmdb.NewMemDB())
 
 	// target
-	param := TransferParam{
+	payload, _ := json.Marshal(TransferParam{
 		To:     []byte("bob"),
 		Amount: *new(types.Currency).Set(1230),
-	}
-	payload, _ := json.Marshal(param)
+	})
 	t1 := makeTestTx("transfer", "alice", payload)
 
-	param = TransferParam{
+	payload, _ = json.Marshal(TransferParam{
 		To:     bob.addr,
 		Amount: *new(types.Currency).Set(500),
-	}
-	payload, _ = json.Marshal(param)
+	})
 	t2 := makeTestTx("transfer", "bob", payload)
 
-	param = TransferParam{
+	payload, _ = json.Marshal(TransferParam{
 		To:     eve.addr,
 		Amount: *new(types.Currency).Set(10),
-	}
-	payload, _ = json.Marshal(param)
+	})
 	t3 := makeTestTx("transfer", "eve", payload)
+
+	payload, _ = json.Marshal(TransferParam{
+		To:     alice.addr,
+		Amount: *new(types.Currency).Set(0),
+	})
+	t4 := makeTestTx("transfer", "eve", payload)
 
 	// test
 	rc, _ := t1.Check()
@@ -593,6 +596,8 @@ func TestNonValidTransfer(t *testing.T) {
 	assert.Equal(t, code.TxCodeSelfTransaction, rc)
 	rc, _, _ = t3.Execute(s)
 	assert.Equal(t, code.TxCodeNotEnoughBalance, rc)
+	rc, _, _ = t4.Execute(s)
+	assert.Equal(t, code.TxCodeUnavailableAmount, rc)
 
 	aliceBal := s.GetBalance(makeTestAddress("alice"), false)
 	assert.Equal(t, new(types.Currency).Set(0), aliceBal)
@@ -609,13 +614,20 @@ func TestValidStake(t *testing.T) {
 	s := store.NewStore(tmdb.NewMemDB(), tmdb.NewMemDB(), tmdb.NewMemDB(), tmdb.NewMemDB())
 	s.SetBalanceUint64(alice.addr, 3000)
 
+	validator := cmn.RandBytes(32)
+
 	// target
-	param := StakeParam{
-		Validator: cmn.RandBytes(32),
+	payload, _ := json.Marshal(StakeParam{
+		Validator: validator,
 		Amount:    *new(types.Currency).Set(2000),
-	}
-	payload, _ := json.Marshal(param)
+	})
 	t1 := makeTestTx("stake", "alice", payload)
+
+	payload, _ = json.Marshal(StakeParam{
+		Validator: validator,
+		Amount:    *new(types.Currency).Set(1000),
+	})
+	t2 := makeTestTx("stake", "alice", payload)
 
 	// test
 	rc, _ := t1.Check()
@@ -623,6 +635,14 @@ func TestValidStake(t *testing.T) {
 
 	rc, _, _ = t1.Execute(s)
 	assert.Equal(t, code.TxCodeOK, rc)
+
+	ConfigLockupPeriod += 1 // manipulate
+
+	rc, _, _ = t2.Execute(s)
+	assert.Equal(t, code.TxCodeOK, rc)
+
+	stake := s.GetStake(alice.addr, false)
+	assert.Equal(t, *new(types.Currency).Set(3000), stake.Amount)
 }
 
 func TestNonValidStake(t *testing.T) {
@@ -631,26 +651,35 @@ func TestNonValidStake(t *testing.T) {
 	s.SetBalanceUint64(alice.addr, 3000)
 
 	// target
-	param := StakeParam{
+	payload, _ := json.Marshal(StakeParam{
+		Validator: cmn.RandBytes(32),
+		Amount:    *new(types.Currency).Set(0),
+	})
+
+	t1 := makeTestTx("stake", "alice", payload)
+
+	payload, _ = json.Marshal(StakeParam{
 		Validator: cmn.RandBytes(32),
 		Amount:    *new(types.Currency).Set(2000),
-	}
-	payload, _ := json.Marshal(param)
-	t1 := makeTestTx("stake", "eve", payload)
+	})
 
-	t2 := makeTestTx("stake", "alice", payload)
+	t2 := makeTestTx("stake", "eve", payload)
+	t3 := makeTestTx("stake", "alice", payload)
 
 	// test
 	rc, _, _ := t1.Execute(s)
+	assert.Equal(t, code.TxCodeUnavailableAmount, rc)
+
+	rc, _, _ = t2.Execute(s)
 	assert.Equal(t, code.TxCodeNotEnoughBalance, rc)
 
 	// env
 	s.SetBalanceUint64(eve.addr, 2000)
-	rc, _, _ = t1.Execute(s)
+	rc, _, _ = t2.Execute(s)
 	assert.Equal(t, code.TxCodeOK, rc)
 
 	// test
-	rc, _, _ = t2.Execute(s)
+	rc, _, _ = t3.Execute(s)
 	assert.Equal(t, code.TxCodePermissionDenied, rc)
 }
 
@@ -708,21 +737,28 @@ func TestNonValidWithdraw(t *testing.T) {
 	})
 
 	// target
-	param := WithdrawParam{
+	payload, _ := json.Marshal(WithdrawParam{
+		Amount: *new(types.Currency).Set(0),
+	})
+	t1 := makeTestTx("withdraw", "alice", payload)
+
+	payload, _ = json.Marshal(WithdrawParam{
 		Amount: *new(types.Currency).Set(2000),
-	}
-	payload, _ := json.Marshal(param)
-	t1 := makeTestTx("withdraw", "eve", payload)
-	t2 := makeTestTx("withdraw", "alice", payload)
+	})
+	t2 := makeTestTx("withdraw", "eve", payload)
+	t3 := makeTestTx("withdraw", "alice", payload)
 
 	// test
 	rc, _, _ := t1.Execute(s)
+	assert.Equal(t, code.TxCodeUnavailableAmount, rc)
+
+	rc, _, _ = t2.Execute(s)
 	assert.Equal(t, code.TxCodeNoStake, rc)
 
-	// test
-	rc, _ = t2.Check()
+	rc, _ = t3.Check()
 	assert.Equal(t, code.TxCodeOK, rc)
-	rc, _, _ = t2.Execute(s)
+
+	rc, _, _ = t3.Execute(s)
 	assert.Equal(t, code.TxCodeLastValidator, rc)
 
 	// env
@@ -732,7 +768,7 @@ func TestNonValidWithdraw(t *testing.T) {
 	})
 
 	// test
-	rc, _, _ = t2.Execute(s)
+	rc, _, _ = t3.Execute(s)
 	assert.Equal(t, code.TxCodeDelegateExists, rc)
 }
 
@@ -789,6 +825,14 @@ func TestNonValidDelegate(t *testing.T) {
 	t1 := makeTestTx("delegate", "eve", payload)
 	rc, _ := t1.Check()
 	assert.Equal(t, code.TxCodeSelfTransaction, rc)
+
+	payload, _ = json.Marshal(DelegateParam{
+		Amount: *new(types.Currency).Set(0),
+		To:     alice.addr,
+	})
+	t1 = makeTestTx("delegate", "eve", payload)
+	rc, _, _ = t1.Execute(s)
+	assert.Equal(t, code.TxCodeUnavailableAmount, rc)
 
 	payload, _ = json.Marshal(DelegateParam{
 		Amount: *new(types.Currency).Set(500),
@@ -877,18 +921,28 @@ func TestNonValidRetract(t *testing.T) {
 	})
 
 	payload, _ := json.Marshal(RetractParam{
+		Amount: *new(types.Currency).Set(0),
+	})
+
+	t1 := makeTestTx("retract", "bob", payload)
+
+	payload, _ = json.Marshal(RetractParam{
 		Amount: *new(types.Currency).Set(500),
 	})
-	t1 := makeTestTx("retract", "eve", payload)
-	t2 := makeTestTx("retract", "bob", payload)
+
+	t2 := makeTestTx("retract", "eve", payload)
+	t3 := makeTestTx("retract", "bob", payload)
 
 	rc, _, _ := t1.Execute(s)
+	assert.Equal(t, code.TxCodeUnavailableAmount, rc)
+
+	rc, _, _ = t2.Execute(s)
 	assert.Equal(t, code.TxCodeDelegateNotFound, rc)
 
-	rc, _, _ = t2.Execute(s)
+	rc, _, _ = t3.Execute(s)
 	assert.Equal(t, code.TxCodeOK, rc)
 
-	rc, _, _ = t2.Execute(s)
+	rc, _, _ = t3.Execute(s)
 	assert.Equal(t, code.TxCodeDelegateNotFound, rc)
 }
 

--- a/amo/tx/withdraw.go
+++ b/amo/tx/withdraw.go
@@ -45,7 +45,7 @@ func (t *TxWithdraw) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
-	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+	if !txParam.Amount.GreaterThan(zero) {
 		return code.TxCodeUnavailableAmount, "unavailable amount", nil
 	}
 

--- a/amo/tx/withdraw.go
+++ b/amo/tx/withdraw.go
@@ -45,6 +45,10 @@ func (t *TxWithdraw) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
+	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+		return code.TxCodeUnavailableAmount, "unavailable amount", nil
+	}
+
 	stake := store.GetStake(t.GetSender(), false)
 	if stake == nil {
 		return code.TxCodeNoStake, "no stake", nil

--- a/amo/tx/withdraw.go
+++ b/amo/tx/withdraw.go
@@ -45,7 +45,7 @@ func (t *TxWithdraw) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
-	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+	if !txParam.Amount.GreaterThan(zero) {
 		return code.TxCodeInvalidAmount, "invalid amount", nil
 	}
 

--- a/amo/tx/withdraw.go
+++ b/amo/tx/withdraw.go
@@ -45,6 +45,10 @@ func (t *TxWithdraw) Execute(store *store.Store) (uint32, string, []tm.KVPair) {
 		return code.TxCodeBadParam, err.Error(), nil
 	}
 
+	if txParam.Amount.Equals(zero) || txParam.Amount.LessThan(zero) {
+		return code.TxCodeInvalidAmount, "invalid amount", nil
+	}
+
 	stake := store.GetStake(t.GetSender(), false)
 	if stake == nil {
 		return code.TxCodeNoStake, "no stake", nil


### PR DESCRIPTION
- set conditions for checking 0 amount while executing txs
- handle stake tx only as a newly generated locked stake
- add test codes for stake and overall txs

resolves https://github.com/amolabs/amoabci/issues/185